### PR TITLE
fix(Improvement): Change commit url+/commit/+ hash  to full hash for …

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -77,13 +77,13 @@ exports.markdown = function (version, commits, options) {
       }
 
       types[type][category].forEach(function (commit) {
-        var hash = commit.hash.substring(0, 8);
+        var shorthash = commit.hash.substring(0, 8);
 
         if (options.repoUrl) {
-          hash = '[' + hash + '](' + options.repoUrl + '/commit/' + hash + ')';
+          shorthash = '[' + shorthash + '](' + options.repoUrl + '/commit/' + commit.hash + ')';
         }
 
-        content.push(prefix + ' ' + commit.subject + ' (' + hash + ')');
+        content.push(prefix + ' ' + commit.subject + ' (' + shorthash + ')');
       });
     });
 


### PR DESCRIPTION
…usage with Git hosted by TFS, but use short hash for text shown to user