### PR TITLE
fix(git): enfore lowercase commit.type

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -46,7 +46,7 @@ exports.getCommits = function () {
       return null;
     }
 
-    commit.type = parsed[1];
+    commit.type = parsed[1].toLowerCase();
     commit.category = parsed[3];
     commit.subject = parsed[4];
 


### PR DESCRIPTION
At the moment commit messages like "Fix(git) something" are grouped with 'Other Changes' instead of 'Bug Fixes'.

This PR makes sure caps in the `commit.type` are all grouped under their lowercase type.