### PR TITLE
Remove incrementation flag requirement

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -62,8 +62,6 @@ exports.calculateNewVersion = function (options) {
       split[2] = '0';
     } else if (options.patch) {
       split[2] = (parseInt(split[2]) + 1).toString();
-    } else {
-      throw new Error('patch, minor, or major needs to be set');
     }
 
     return split.join('.');

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -141,20 +141,6 @@ describe('package', function () {
       });
     });
 
-    it('errs if patch, minor, and major are all false', function () {
-      var options = {};
-
-      return Package.calculateNewVersion(options)
-      .bind({})
-      .catch(function (err) {
-        this.err = err;
-      })
-      .finally(function () {
-        Expect(this.err).to.be.instanceof(Error);
-        Expect(this.err.message).to.eql('patch, minor, or major needs to be set');
-      });
-    });
-
   });
 
 });


### PR DESCRIPTION
Removes the error that requires an incrementation flag type to be set. npm supports a number of other incrementation flags (like prerelease) which could be complicated to add here.

I agree with the general usage advice, and am glad the docs provide those examples. In more complex or legacy build systems, it might be more convenient for a team to manually update the version number before generating the changelog (as opposed to using `npm version`). This update provides more flexibility for that use case.