### PR TITLE
Add "exclude" option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,11 +4,16 @@ var CLI = require('commander');
 
 var Package = require('../package');
 
+function list (val) {
+  return val.split(',');
+}
+
 module.exports = CLI
   .description('Generate a changelog from git commits.')
   .version(Package.version)
   .option('-p, --patch', 'create a patch changelog')
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
+  .option('-x, --exclude', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');

--- a/lib/git.js
+++ b/lib/git.js
@@ -9,9 +9,11 @@ var FORMAT         = '%H%n%s%n%b%n' + SEPARATOR;
 
 /**
  * Get all commits from the last tag (or the first commit if no tags).
+ * @param {Object} options - calculation options
  * @returns {Promise<Array<Object>>} array of parsed commit objects
  */
-exports.getCommits = function () {
+exports.getCommits = function (options) {
+  options = options || {};
   return CP.execAsync('git describe --tags --abbrev=0')
   .catch(function () {
     return '';
@@ -53,6 +55,9 @@ exports.getCommits = function () {
     return commit;
   })
   .filter(function (commit) {
-    return commit !== null;
+    if (!commit) {
+      return false;
+    }
+    return options.exclude ? (options.exclude.indexOf(commit.type) !== -1) : true;
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,13 +13,14 @@ var Writer  = require('./writer');
  * @param {Boolean} options.minor - whether it should be a minor changelog
  * @param {Boolean} options.major - whether it should be a major changelog
  * @param {String} options.repoUrl - repo URL that will be used when linking commits
+ * @param {Array} options.exclude - exclude listed commit types (e.g. ['chore', 'style', 'refactor'])
  * @returns {Promise<String>} the \n separated changelog string
  */
 exports.generate = function (options) {
   return Bluebird.all([
     Package.extractRepoUrl(),
     Package.calculateNewVersion(options),
-    Git.getCommits()
+    Git.getCommits(options)
   ])
   .spread(function (repoUrl, version, commits) {
     options.repoUrl = options.repoUrl || repoUrl;

--- a/lib/package.js
+++ b/lib/package.js
@@ -49,6 +49,7 @@ exports.extractRepoUrl = function () {
  * @returns {Promise<String>} - new version
  */
 exports.calculateNewVersion = function (options) {
+  options = options || {};
   return exports.getUserPackage()
   .then(function (userPackage) {
     var split = userPackage.version.split('.');

--- a/test/data/git/valid-commits.txt
+++ b/test/data/git/valid-commits.txt
@@ -6,3 +6,15 @@ a2c164a718e45d7d3c5e37eec2008a3ebf371e93
 feat(testing): did some testing
 
 ===END===
+9bbdcf32e1c46176c4cbdcef329ada45fed0bf5a
+chore(release): 1.2.3
+New release
+===END===
+e45d7d3c5e37eec2008a3ebf371e93a2c164a718
+style(all): reviewed semicolons usage
+
+===END===
+e45d7d3c5e37eec2008a3ebf371e93a2c164a718
+test: add test coverage
+
+===END===

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -63,7 +63,7 @@ describe('git', function () {
 
       return Git.getCommits()
       .then(function (commits) {
-        Expect(commits).to.have.length(1);
+        Expect(commits).to.have.length(4);
         Expect(commits[0]).to.have.property('type');
         Expect(commits[0]).to.have.property('category');
         Expect(commits[0]).to.have.property('subject');
@@ -79,6 +79,18 @@ describe('git', function () {
       return Git.getCommits()
       .then(function (commits) {
         Expect(commits).to.have.length(0);
+        CP.execAsync.restore();
+      });
+    });
+
+    it('skips any excluded commit types', function () {
+      Sinon.stub(CP, 'execAsync')
+        .onFirstCall().returns(Bluebird.resolve('v1.2.3'))
+        .onSecondCall().returns(Bluebird.resolve(VALID_COMMITS));
+
+      return Git.getCommits({ exclude: ['chore', 'style'] })
+      .then(function (commits) {
+        Expect(commits).to.have.length(2);
         CP.execAsync.restore();
       });
     });

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -114,12 +114,12 @@ describe('package', function () {
       Package.getUserPackage.restore();
     });
 
-    it('bumps the patch version if patch is true', function () {
-      var options = { patch: true };
+    it('bumps the major version if major is true', function () {
+      var options = { major: true };
 
       return Package.calculateNewVersion(options)
       .then(function (version) {
-        Expect(version).to.eql('1.2.4');
+        Expect(version).to.eql('2.0.0');
       });
     });
 
@@ -132,15 +132,21 @@ describe('package', function () {
       });
     });
 
-    it('bumps the major version if major is true', function () {
-      var options = { major: true };
+    it('bumps the patch version if patch is true', function () {
+      var options = { patch: true };
 
       return Package.calculateNewVersion(options)
       .then(function (version) {
-        Expect(version).to.eql('2.0.0');
+        Expect(version).to.eql('1.2.4');
       });
     });
 
+    it('leaves the version untouched if none of three options is true', function () {
+      return Package.calculateNewVersion()
+      .then(function (version) {
+        Expect(version).to.eql('1.2.3');
+      });
+    });
   });
 
 });


### PR DESCRIPTION
I added `-x, --exclude` option, which is sometimes useful, if you don't want your `chore`, `refactor` or `style` commits to appear in the changelog.
I also fixed the annoying 97.78% coverage on branches issue