### PR TITLE
fix(exclude): REALLY exclude listed commit types

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -58,6 +58,6 @@ exports.getCommits = function (options) {
     if (!commit) {
       return false;
     }
-    return options.exclude ? (options.exclude.indexOf(commit.type) !== -1) : true;
+    return options.exclude ? (options.exclude.indexOf(commit.type) === -1) : true;
   });
 };

--- a/test/data/git/valid-commits.txt
+++ b/test/data/git/valid-commits.txt
@@ -6,6 +6,10 @@ a2c164a718e45d7d3c5e37eec2008a3ebf371e93
 feat(testing): did some testing
 
 ===END===
+a2c164a718e45d7d3c5e37eec2008a3ebf371e94
+feat(testing): did some more testing
+
+===END===
 9bbdcf32e1c46176c4cbdcef329ada45fed0bf5a
 chore(release): 1.2.3
 New release

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -63,7 +63,7 @@ describe('git', function () {
 
       return Git.getCommits()
       .then(function (commits) {
-        Expect(commits).to.have.length(4);
+        Expect(commits).to.have.length(5);
         Expect(commits[0]).to.have.property('type');
         Expect(commits[0]).to.have.property('category');
         Expect(commits[0]).to.have.property('subject');
@@ -90,7 +90,7 @@ describe('git', function () {
 
       return Git.getCommits({ exclude: ['chore', 'style'] })
       .then(function (commits) {
-        Expect(commits).to.have.length(2);
+        Expect(commits).to.have.length(3);
         CP.execAsync.restore();
       });
     });


### PR DESCRIPTION
None of us have noticed that the `exclude` option was working in exactly opposite way as it should! :joy:

I've already taken 24 lashes on my back :wink: