### PR TITLE
feat(writer): update commit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,16 @@ type(category): description
 
 Where `type` is one of the following:
 
+* `build`
+* `ci`
 * `chore`
 * `docs`
 * `feat`
 * `fix`
 * `other`
+* `perf`
 * `refactor`
+* `revert`
 * `style`
 * `test`
 
@@ -54,6 +58,7 @@ $ changelog -h
     -p, --patch           create a patch changelog
     -m, --minor           create a minor changelog
     -M, --major           create a major changelog
+    -x, --exclude         exclude selected commit types (comma separated)
     -f, --file [file]     file to write to, defaults to ./CHANGELOG.md, use - for stdout
     -u, --repo-url [url]  specify the repo URL for commit links, defaults to checking the package.json
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -4,12 +4,16 @@ var Bluebird = require('bluebird');
 
 var DEFAULT_TYPE = 'other';
 var TYPES = {
+  build: 'Build System / Dependencies',
+  ci: 'Continuous Integration',
   chore: 'Chores',
   docs: 'Documentation Changes',
   feat: 'New Features',
   fix: 'Bug Fixes',
   other: 'Other Changes',
+  perf: 'Performance Improvements',
   refactor: 'Refactors',
+  revert: 'Reverts',
   style: 'Code Style Changes',
   test: 'Tests'
 };


### PR DESCRIPTION
Just an update of commit types / categories based on [conventional-changelog types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json)