### PR TITLE
fix(exclude): allow arguments to be passed in to -x

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ $ changelog -h
 
   Options:
 
-    -h, --help            output usage information
-    -V, --version         output the version number
-    -p, --patch           create a patch changelog
-    -m, --minor           create a minor changelog
-    -M, --major           create a major changelog
-    -x, --exclude         exclude selected commit types (comma separated)
-    -f, --file [file]     file to write to, defaults to ./CHANGELOG.md, use - for stdout
-    -u, --repo-url [url]  specify the repo URL for commit links, defaults to checking the package.json
+    -h, --help             output usage information
+    -V, --version          output the version number
+    -p, --patch            create a patch changelog
+    -m, --minor            create a minor changelog
+    -M, --major            create a major changelog
+    -x, --exclude <types>  exclude selected commit types (comma separated)
+    -f, --file [file]      file to write to, defaults to ./CHANGELOG.md, use - for stdout
+    -u, --repo-url [url]   specify the repo URL for commit links, defaults to checking the package.json
 
 ```
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,6 @@ module.exports = CLI
   .option('-p, --patch', 'create a patch changelog')
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
-  .option('-x, --exclude', 'exclude selected commit types (comma separated)', list)
+  .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');


### PR DESCRIPTION
Allow for arguments to be passed into `-x` since right now it's being interpreted as a boolean. Fixes #22 