### PR TITLE
feat(package): Add support for missing version

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -53,7 +53,7 @@ exports.calculateNewVersion = function (options) {
   return exports.getUserPackage()
   .then(function (userPackage) {
     if (!userPackage.version) {
-      return false;
+      return null;
     }
 
     var split = userPackage.version.split('.');

--- a/lib/package.js
+++ b/lib/package.js
@@ -52,19 +52,23 @@ exports.calculateNewVersion = function (options) {
   options = options || {};
   return exports.getUserPackage()
   .then(function (userPackage) {
-    var split = userPackage.version.split('.');
+    if (userPackage.version) {
+      var split = userPackage.version.split('.');
 
-    if (options.major) {
-      split[0] = (parseInt(split[0]) + 1).toString();
-      split[1] = '0';
-      split[2] = '0';
-    } else if (options.minor) {
-      split[1] = (parseInt(split[1]) + 1).toString();
-      split[2] = '0';
-    } else if (options.patch) {
-      split[2] = (parseInt(split[2]) + 1).toString();
+      if (options.major) {
+        split[0] = (parseInt(split[0]) + 1).toString();
+        split[1] = '0';
+        split[2] = '0';
+      } else if (options.minor) {
+        split[1] = (parseInt(split[1]) + 1).toString();
+        split[2] = '0';
+      } else if (options.patch) {
+        split[2] = (parseInt(split[2]) + 1).toString();
+      }
+
+      return split.join('.');
+    } else {
+      return 'Unknown version';
     }
-
-    return split.join('.');
   });
 };

--- a/lib/package.js
+++ b/lib/package.js
@@ -52,23 +52,23 @@ exports.calculateNewVersion = function (options) {
   options = options || {};
   return exports.getUserPackage()
   .then(function (userPackage) {
-    if (userPackage.version) {
-      var split = userPackage.version.split('.');
-
-      if (options.major) {
-        split[0] = (parseInt(split[0]) + 1).toString();
-        split[1] = '0';
-        split[2] = '0';
-      } else if (options.minor) {
-        split[1] = (parseInt(split[1]) + 1).toString();
-        split[2] = '0';
-      } else if (options.patch) {
-        split[2] = (parseInt(split[2]) + 1).toString();
-      }
-
-      return split.join('.');
-    } else {
-      return 'Unknown version';
+    if (!userPackage.version) {
+      return false;
     }
+
+    var split = userPackage.version.split('.');
+
+    if (options.major) {
+      split[0] = (parseInt(split[0]) + 1).toString();
+      split[1] = '0';
+      split[2] = '0';
+    } else if (options.minor) {
+      split[1] = (parseInt(split[1]) + 1).toString();
+      split[2] = '0';
+    } else if (options.patch) {
+      split[2] = (parseInt(split[2]) + 1).toString();
+    }
+
+    return split.join('.');
   });
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -42,7 +42,11 @@ exports.markdown = function (version, commits, options) {
     heading = '####';
   }
 
-  heading += ' ' + version + ' (' + date + ')';
+  if (version) {
+    heading += ' ' + version + ' (' + date + ')';
+  } else {
+    heading += ' ' + date;
+  }
 
   content.push(heading);
   content.push('');

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -148,7 +148,7 @@ describe('package', function () {
       });
     });
 
-    it('returns null if no version is specified', function() {
+    it('returns null if no version is specified', function () {
       Package.getUserPackage.restore();
       Sinon.stub(Package, 'getUserPackage').returns(Bluebird.resolve({ version: '' }));
 

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -154,9 +154,10 @@ describe('package', function () {
 
       return Package.calculateNewVersion()
       .then(function (version) {
-        Expect(version).to.eql(null);
+        Expect(version).to.be.null;
       });
     });
+
   });
 
 });

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -147,6 +147,16 @@ describe('package', function () {
         Expect(version).to.eql('1.2.3');
       });
     });
+
+    it('returns null if no version is specified', function() {
+      Package.getUserPackage.restore();
+      Sinon.stub(Package, 'getUserPackage').returns(Bluebird.resolve({ version: '' }));
+
+      return Package.calculateNewVersion()
+      .then(function (version) {
+        Expect(version).to.eql(null);
+      });
+    });
   });
 
 });

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -50,7 +50,7 @@ describe('writer', function () {
       .then(function (changelog) {
         var heading = changelog.split('\n')[0];
 
-        Expect(heading).to.equal('## ' + new Date().toJSON().slice(0,10));
+        Expect(heading).to.equal('## ' + new Date().toJSON().slice(0, 10));
       });
     });
 

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -43,6 +43,17 @@ describe('writer', function () {
       });
     });
 
+    it('keeps only the date if no version is specified', function () {
+      var options = { major: true };
+
+      return Writer.markdown(false, [], options)
+      .then(function (changelog) {
+        var heading = changelog.split('\n')[0];
+
+        Expect(heading).to.equal('## ' + new Date().toJSON().slice(0,10));
+      });
+    });
+
     it('flushes out a commit type with its full name', function () {
       var commits = [
         { type: 'feat', category: 'testing', subject: 'did some testing', hash: '1234567890' }


### PR DESCRIPTION
This commit adds support for projects without a `version` field in the `package.json` file.

Fixes #24.