### PR TITLE
feat(git): generate from specific tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ changelog -h
     -p, --patch            create a patch changelog
     -m, --minor            create a minor changelog
     -M, --major            create a major changelog
-    -t, --tag              generate from specific tag
+    -t, --tag <range>      generate from specific tag or range (e.g. v1.2.3 or v1.2.3..v1.2.4)
     -x, --exclude <types>  exclude selected commit types (comma separated)
     -f, --file [file]      file to write to, defaults to ./CHANGELOG.md, use - for stdout
     -u, --repo-url [url]   specify the repo URL for commit links, defaults to checking the package.json

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ changelog -h
     -p, --patch            create a patch changelog
     -m, --minor            create a minor changelog
     -M, --major            create a major changelog
+    -t, --tag              generate from specific tag
     -x, --exclude <types>  exclude selected commit types (comma separated)
     -f, --file [file]      file to write to, defaults to ./CHANGELOG.md, use - for stdout
     -u, --repo-url [url]   specify the repo URL for commit links, defaults to checking the package.json

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,7 @@ module.exports = CLI
   .option('-p, --patch', 'create a patch changelog')
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
-  .option('-t, --tag', 'generate from specific tag')
+  .option('-t, --tag [range]', 'generate from specific tag', '')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,7 @@ module.exports = CLI
   .option('-p, --patch', 'create a patch changelog')
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
+  .option('-t, --tag', 'generate from specific tag')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,7 @@ module.exports = CLI
   .option('-p, --patch', 'create a patch changelog')
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
-  .option('-t, --tag [range]', 'generate from specific tag', '')
+  .option('-t, --tag <range>', 'generate from specific tag or range (e.g. v1.2.3 or v1.2.3..v1.2.4)')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');

--- a/lib/git.js
+++ b/lib/git.js
@@ -16,7 +16,7 @@ exports.getCommits = function (options) {
   options = options || {};
   return new Bluebird(function (resolve) {
     if (options.tag) {
-      return resolve(options.args[0]);
+      return resolve(options.tag);
     }
     return resolve(CP.execAsync('git describe --tags --abbrev=0'));
   })

--- a/lib/git.js
+++ b/lib/git.js
@@ -14,13 +14,24 @@ var FORMAT         = '%H%n%s%n%b%n' + SEPARATOR;
  */
 exports.getCommits = function (options) {
   options = options || {};
-  return CP.execAsync('git describe --tags --abbrev=0')
+  return new Bluebird(function (resolve) {
+    if (options.tag) {
+      return resolve(options.args[0]);
+    }
+    return resolve(CP.execAsync('git describe --tags --abbrev=0'));
+  })
   .catch(function () {
     return '';
   })
   .then(function (tag) {
     tag = tag.toString().trim();
-    var revisions = tag ? tag + '..HEAD' : '';
+    var revisions;
+
+    if (tag.indexOf('..') !== -1) {
+      revisions = tag;
+    } else {
+      revisions = tag ? tag + '..HEAD' : '';
+    }
 
     return CP.execAsync('git log -E --format=' + FORMAT + ' ' + revisions);
   })

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -43,7 +43,7 @@ describe('git', function () {
       Sinon.stub(CP, 'execAsync')
         .onFirstCall().returns(Bluebird.resolve(VALID_COMMITS));
 
-      var tagRange = 'aabbccdd..eeffgghh';
+      var tagRange = 'abcdef01..23456789';
 
       return Git.getCommits({ tag: tagRange })
       .then(function () {

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -39,7 +39,20 @@ describe('git', function () {
       });
     });
 
-    it('errs if there are no commits yet', function () {
+    it('uses custom revision range if `-t` / `--tag` option was used', function () {
+      Sinon.stub(CP, 'execAsync')
+        .onFirstCall().returns(Bluebird.resolve(VALID_COMMITS));
+
+      var tagRange = 'aabbccdd..eeffgghh';
+
+      return Git.getCommits({ tag: tagRange })
+      .then(function () {
+        CP.execAsync.firstCall.calledWithMatch(tagRange);
+        CP.execAsync.restore();
+      });
+    });
+
+    it('errors if there are no commits yet', function () {
       Sinon.stub(CP, 'execAsync')
         .onFirstCall().returns(Bluebird.resolve('v1.2.3'))
         .onSecondCall().returns(Bluebird.reject());


### PR DESCRIPTION
This pull request lets the user generate a changelog back from a specific commit, across branches and within commit ranges. Fixes #27.

Example: `generate -p 420c945...2a83752` or `generate -p master..new-branch`.

This PR is still missing tests but unfortunately I don't really know how to write them since I am not very experienced with Sinon and wouldn't know how to test the CLI. Maybe @robinjoseph08 can help?