### PR TITLE
feat(writer): Add links to PRs numbers in commits text

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -18,6 +18,8 @@ var TYPES = {
   test: 'Tests'
 };
 
+var PR_REGEX = new RegExp(/#[1-9][\d]*/g);
+
 /**
  * Generate the markdown for the changelog.
  * @param {String} version - the new version affiliated to this changelog
@@ -85,12 +87,17 @@ exports.markdown = function (version, commits, options) {
 
       types[type][category].forEach(function (commit) {
         var shorthash = commit.hash.substring(0, 8);
+        var subject = commit.subject;
 
         if (options.repoUrl) {
           shorthash = '[' + shorthash + '](' + options.repoUrl + '/commit/' + commit.hash + ')';
+
+          subject = subject.replace(PR_REGEX, function (pr) {
+            return '[' + pr + '](' + options.repoUrl + '/pull/' + pr.slice(1) + ')';
+          });
         }
 
-        content.push(prefix + ' ' + commit.subject + ' (' + shorthash + ')');
+        content.push(prefix + ' ' + subject + ' (' + shorthash + ')');
       });
     });
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -3,6 +3,7 @@
 var Bluebird = require('bluebird');
 
 var DEFAULT_TYPE = 'other';
+var PR_REGEX = new RegExp(/#[1-9][\d]*/g);
 var TYPES = {
   build: 'Build System / Dependencies',
   ci: 'Continuous Integration',
@@ -17,8 +18,6 @@ var TYPES = {
   style: 'Code Style Changes',
   test: 'Tests'
 };
-
-var PR_REGEX = new RegExp(/#[1-9][\d]*/g);
 
 /**
  * Generate the markdown for the changelog.

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -216,6 +216,49 @@ describe('writer', function () {
       });
     });
 
+    it('wraps an issue/pr number if a repoUrl is provided', function () {
+      var category = 'testing';
+      var url = 'https://github.com/lob/generate-changelog';
+      var pr = 7;
+      var commits = [
+        { type: 'feat', category: category, subject: 'Merge pull request #' + pr + 'from some/repo', hash: '1234567890' }
+      ];
+
+      return Writer.markdown(VERSION, commits, { repoUrl: url })
+      .then(function (changelog) {
+        return changelog.split('\n');
+      })
+      .filter(function (line) {
+        return line.indexOf(category) > -1;
+      })
+      .get(0)
+      .then(function (line) {
+        Expect(line).to.contain('[#' + pr + '](' + url + '/pull/' + pr + ')');
+      });
+    });
+
+    it('wraps more than one issue/pr numbers in one commit if a repoUrl is provided', function () {
+      var category = 'testing';
+      var url = 'https://github.com/lob/generate-changelog';
+      var prs = [7, 42];
+      var commits = [
+        { type: 'feat', category: category, subject: 'fixes (#' + prs[0] + '): added some (#' + prs[1] + ')', hash: '1234567890' }
+      ];
+
+      return Writer.markdown(VERSION, commits, { repoUrl: url })
+      .then(function (changelog) {
+        return changelog.split('\n');
+      })
+      .filter(function (line) {
+        return line.indexOf(category) > -1;
+      })
+      .get(0)
+      .then(function (line) {
+        Expect(line).to.contain('[#' + prs[0] + '](' + url + '/pull/' + prs[0] + ')');
+        Expect(line).to.contain('[#' + prs[1] + '](' + url + '/pull/' + prs[1] + ')');
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
closes #30 

* treats PRs and issues urls the same, as GitHub does this itself and reroutes between '.../issues/<NUMBER>' and '.../pull/<NUMBER>' when it is required