### PR TITLE
fix(writer): Fix commit URL for BitBucket repos (#12)

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -20,6 +20,22 @@ var TYPES = {
 };
 
 /**
+ * Generate the commit URL for the repository provider.
+ * @param {String} baseUrl - The base URL for the project
+ * @param {String} commitHash - The commit hash being linked
+ * @return {String} The URL pointing to the commit
+ */
+exports.getCommitUrl = function (baseUrl, commitHash) {
+  var urlCommitName = 'commit';
+
+  if (baseUrl.indexOf('bitbucket') !== -1) {
+    urlCommitName = 'commits';
+  }
+
+  return baseUrl + '/' + urlCommitName + '/' + commitHash;
+};
+
+/**
  * Generate the markdown for the changelog.
  * @param {String} version - the new version affiliated to this changelog
  * @param {Array<Object>} commits - array of parsed commit objects
@@ -89,7 +105,7 @@ exports.markdown = function (version, commits, options) {
         var subject = commit.subject;
 
         if (options.repoUrl) {
-          shorthash = '[' + shorthash + '](' + options.repoUrl + '/commit/' + commit.hash + ')';
+          shorthash = '[' + shorthash + '](' + exports.getCommitUrl(options.repoUrl, commit.hash) + ')';
 
           subject = subject.replace(PR_REGEX, function (pr) {
             return '[' + pr + '](' + options.repoUrl + '/pull/' + pr.slice(1) + ')';

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -8,6 +8,26 @@ var VERSION = '1.2.3';
 
 describe('writer', function () {
 
+  describe('getCommitUrl', function () {
+
+    it('makes a valid URL for a BitBucket repository', function () {
+      var url = 'https://bitbucket.org/lob/generate-changelog';
+      var commitHash = '1234567890';
+
+      var linkUrl = Writer.getCommitUrl(url, commitHash);
+      Expect(linkUrl).to.equal(url + '/commits/' + commitHash);
+    });
+
+    it('makes a valid URL for a GitHub repository', function () {
+      var url = 'https://github.com/lob/generate-changelog';
+      var commitHash = '1234567890';
+
+      var linkUrl = Writer.getCommitUrl(url, commitHash);
+      Expect(linkUrl).to.equal(url + '/commit/' + commitHash);
+    });
+
+  });
+
   describe('markdown', function () {
 
     it('makes heading h2 if major version', function () {


### PR DESCRIPTION
Fixes #12

Fix the writer to generate a proper commit URL for BitBucket
repositories. BitBucket repositories have a slightly different URL
pattern than GitHub repositories.