### PR TITLE
feat(types): add option to change or append types

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,4 +17,5 @@ module.exports = CLI
   .option('-t, --tag <range>', 'generate from specific tag or range (e.g. v1.2.3 or v1.2.3..v1.2.4)')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
-  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');
+  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json')
+  .option('-y, --types <json>', 'use these types in json format (e.g. {"bug":"Bug Fixes"})');

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -15,7 +15,7 @@ module.exports = CLI
   .option('-m, --minor', 'create a minor changelog')
   .option('-M, --major', 'create a major changelog')
   .option('-t, --tag <range>', 'generate from specific tag or range (e.g. v1.2.3 or v1.2.3..v1.2.4)')
+  .option('-y, --types <json>', 'merge/replace with these types. In valid json format (no whitespace out of quotes). (e.g. {"bug":"Bug Fixes","enhance":"Enhancements","fix":"Custom Fixes Heading"})')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
-  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json')
-  .option('-y, --types <json>', 'use these types in json format (e.g. {"bug":"Bug Fixes"})');
+  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var Writer  = require('./writer');
  * @returns {Promise<String>} the \n separated changelog string
  */
 exports.generate = function (options) {
+  /* TODO create a config file that is fetched, parsed and overridden by options, something to make repetitive tasks a joy for the dev */
   return Bluebird.all([
     Package.extractRepoUrl(),
     Package.calculateNewVersion(options),

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -17,7 +17,7 @@ var TYPES = {
   refactor: 'Refactors',
   revert: 'Reverts',
   style: 'Code Style Changes',
-  test: 'Tests',
+  test: 'Tests'
 };
 
 /**

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -17,7 +17,7 @@ var TYPES = {
   refactor: 'Refactors',
   revert: 'Reverts',
   style: 'Code Style Changes',
-  test: 'Tests'
+  test: 'Tests',
 };
 
 /**
@@ -69,19 +69,21 @@ exports.markdown = function (version, commits, options) {
   content.push(heading);
   content.push('');
 
-  try {
-    if (typeof options.types === 'string' && options.types.length > 0) {
-    /* fix issues with commandline in windows where quotes are removed or just nay malformed json string */
-      options.types = JSON.parse(options.types.replace(/([{,]*)?\s*?(\w*?)\s*?:\s*?([\w| ]*?)\s*?([,}])/gm, '$1"$2":"$3"$4'));
+  if (options.types !== undefined) {
+    try {
+      if (typeof options.types === 'string' && options.types.length > 0) {
+        /* fix issues with commandline in windows where quotes are removed or just nay malformed json string */
+        options.types = JSON.parse(options.types.replace(/([{,]*)?\s*?(\w*?)\s*?:\s*?([\w| ]*?)\s*?([,}])/gm, '$1"$2":"$3"$4'));
+      }
+    } catch (e) {
+      throw new SyntaxError();
     }
-  } catch (e) {
-    throw new SyntaxError();
-  }
 
-  try {
-    TYPES = Object.assign(TYPES, typeof options.types === 'object' && options.types || {});
-  } catch (e) {
-    throw new Error('Couldn\'t merge types options into default!');
+    try {
+      TYPES = Object.assign(TYPES, typeof options.types === 'object' && options.types || {});
+    } catch (e) {
+      throw new Error('Couldn\'t merge provided types options into default options!');
+    }
   }
 
   return Bluebird.resolve(commits)

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -70,9 +70,18 @@ exports.markdown = function (version, commits, options) {
   content.push('');
 
   try {
-    TYPES = Object.assign(TYPES, typeof options.types === 'string' && JSON.parse(options.types) || typeof options.types === 'object' && options.types || {});
+    if (typeof options.types === 'string' && options.types.length > 0) {
+    /* fix issues with commandline in windows where quotes are removed or just nay malformed json string */
+      options.types = JSON.parse(options.types.replace(/([{,]*)?\s*?(\w*?)\s*?:\s*?([\w| ]*?)\s*?([,}])/gm, '$1"$2":"$3"$4'));
+    }
   } catch (e) {
-    throw new Error('Invalid types');
+    throw new SyntaxError();
+  }
+
+  try {
+    TYPES = Object.assign(TYPES, typeof options.types === 'object' && options.types || {});
+  } catch (e) {
+    throw new Error('Couldn\'t merge types options into default!');
   }
 
   return Bluebird.resolve(commits)

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -69,6 +69,12 @@ exports.markdown = function (version, commits, options) {
   content.push(heading);
   content.push('');
 
+  try {
+    TYPES = Object.assign(TYPES, typeof options.types === 'string' && JSON.parse(options.types) || typeof options.types === 'object' && options.types || {});
+  } catch (e) {
+    throw new Error('Invalid types');
+  }
+
   return Bluebird.resolve(commits)
   .bind({ types: {} })
   .each(function (commit) {


### PR DESCRIPTION
There is a reason to think that this package can be used with non-angular commits that follow the convention of `type(scope): subject`, I for one am making my own lib that does versioning and uses these conventions. However, I wanted a different way to represent the types and their headings etc...

This lib rocks!