### PR TITLE
fix(writer): fix commit URL for Gitlab repos

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -33,8 +33,7 @@ exports.getCommitUrl = function (baseUrl, commitHash) {
     urlCommitName = 'commits';
   }
 
-  
-  if(baseUrl.indexOf('gitlab') > -1 && baseUrl.slice(-4) === '.git'){
+  if (baseUrl.indexOf('gitlab') > -1 && baseUrl.slice(-4) === '.git') {
     baseUrl = baseUrl.slice(0, -4);
   }
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -33,6 +33,11 @@ exports.getCommitUrl = function (baseUrl, commitHash) {
     urlCommitName = 'commits';
   }
 
+  
+  if(baseUrl.indexOf('gitlab') > -1 && baseUrl.slice(-4) === '.git'){
+    baseUrl = baseUrl.slice(0, -4);
+  }
+
   return baseUrl + '/' + urlCommitName + '/' + commitHash;
 };
 

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -33,7 +33,7 @@ exports.getCommitUrl = function (baseUrl, commitHash) {
     urlCommitName = 'commits';
   }
 
-  if (baseUrl.indexOf('gitlab') > -1 && baseUrl.slice(-4) === '.git') {
+  if (baseUrl.indexOf('gitlab') !== -1 && baseUrl.slice(-4) === '.git') {
     baseUrl = baseUrl.slice(0, -4);
   }
 

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -28,7 +28,7 @@ describe('writer', function () {
 
     it('makes a valid URL for a Gitlab repository', function () {
       var url = 'https://gitlab.com/lob/generate-changelog.git';
-      var expectedUrl = 'https://gitlab.com/lob/generate-changelog'
+      var expectedUrl = 'https://gitlab.com/lob/generate-changelog';
       var commitHash = '1234567890';
 
       var linkUrl = Writer.getCommitUrl(url, commitHash);

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -26,6 +26,15 @@ describe('writer', function () {
       Expect(linkUrl).to.equal(url + '/commit/' + commitHash);
     });
 
+    it('makes a valid URL for a Gitlab repository', function () {
+      var url = 'https://gitlab.com/lob/generate-changelog.git';
+      var expectedUrl = 'https://gitlab.com/lob/generate-changelog'
+      var commitHash = '1234567890';
+
+      var linkUrl = Writer.getCommitUrl(url, commitHash);
+      Expect(linkUrl).to.equal(expectedUrl + '/commit/' + commitHash);
+    });
+
   });
 
   describe('markdown', function () {


### PR DESCRIPTION
The baseUrl for gitlab repos has a `.git` at the end of it, but the commit url doesnt, making the links to the commits look like:

<img width="719" alt="screen shot 2018-03-26 at 14 25 01" src="https://user-images.githubusercontent.com/283690/37906174-8a2fc4d8-3101-11e8-8f46-bf5de503e190.png">


This pull request fixes that issue. Test with an example is added.