### PR TITLE
fix(git): Git commit search regex pattern improved to disable space chars in commit subject

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -4,7 +4,7 @@ var Bluebird = require('bluebird');
 var CP       = Bluebird.promisifyAll(require('child_process'));
 
 var SEPARATOR      = '===END===';
-var COMMIT_PATTERN = /^([^)]*)(?:\(([^)]*?)\)|):(.*?(?:\[([^\]]+?)\]|))\s*$/;
+var COMMIT_PATTERN = /^([^) ]*)(?:\(([^)]*?)\)|):(.*?(?:\[([^\]]+?)\]|))\s*$/;
 var FORMAT         = '%H%n%s%n%b%n' + SEPARATOR;
 
 /**


### PR DESCRIPTION
A bug in the regex pattern was causing all commit subjects which contain colon to catch by regex. Fixed by disabling space character in `type`.

Before this change, this commit message was cauch by regex:

`'Merge branch \'master\' of github.com:erayalakese/adventure'` 

which shouldn't be in the change log.