### PR TITLE
Quick typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ changelog -h
     -x, --exclude <types>  exclude selected commit types (comma separated)
     -f, --file [file]      file to write to, defaults to ./CHANGELOG.md, use - for stdout
     -u, --repo-url [url]   specify the repo URL for commit links, defaults to checking the package.json
-    -a, --allow-unknown    allow unkown commit types
+    -a, --allow-unknown    allow unknown commit types
 ```
 
 It's possible to create a `./CHANGELOG.md` file for a specific commit range:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,4 +18,4 @@ module.exports = CLI
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
   .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json')
-  .option('-a, --allow-unknown', 'allow unkown commit types');
+  .option('-a, --allow-unknown', 'allow unknown commit types');


### PR DESCRIPTION
Fixing two typos from https://github.com/lob/generate-changelog/commit/b2fb9ff5517b7be309f6050dd7b557b53668e56b -
```diff
- unkown
+ unknown
```