### PR TITLE
fix: exclude other

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -82,10 +82,4 @@ exports.getCommits = function (options) {
 
     return commit;
   })
-  .filter(function (commit) {
-    if (!commit) {
-      return false;
-    }
-    return options.exclude ? options.exclude.indexOf(commit.type) === -1 : true;
-  });
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -79,7 +79,7 @@ exports.markdown = function (version, commits, options) {
     if (!commit) {
       return false;
     }
-    return options.exclude ? options.exclude.indexOf(options.allowUnknown ? commit.type : DEFAULT_TYPE) === -1 : true;
+    return options.exclude ? options.exclude.indexOf((!options.allowUnknown && TYPES[commit.type]) ? commit.type : DEFAULT_TYPE) === -1 : true;
   })
   .each(function (commit) {
     var type = TYPES[commit.type] || options.allowUnknown ? commit.type : DEFAULT_TYPE;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -75,6 +75,12 @@ exports.markdown = function (version, commits, options) {
 
   return Bluebird.resolve(commits)
   .bind({ types: {} })
+  .filter(function (commit) {
+    if (!commit) {
+      return false;
+    }
+    return options.exclude ? options.exclude.indexOf(options.allowUnknown ? commit.type : DEFAULT_TYPE) === -1 : true;
+  })
   .each(function (commit) {
     var type = TYPES[commit.type] || options.allowUnknown ? commit.type : DEFAULT_TYPE;
     var category = commit.category;


### PR DESCRIPTION
the filtering based on exclude array was taking place before unknown types were translated into `other`

closes #71 